### PR TITLE
feat: ensures JSON.stringify correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .vscode
 
 .DS_store
+.idea

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ let stringifyFunc = (msg: any): string => {
     stringMsg = msg.message + " ";
   } else {
     try {
-      stringMsg = "\n" + JSON.stringify(msg, undefined, 2) + "\n";
+      stringMsg = "\n" + JSON.stringify(msg, Object.getOwnPropertyNames(msg), 2) + "\n";
     } catch (error) {
       stringMsg += "Undefined Message";
     }


### PR DESCRIPTION
## Context
There is a possibility that msg is an object with unenumerated properties, if this happens, those properties will not be logged, this is quite common when dealing with an error instance object. This PR guarantees that all properties will be logged.

## Solution
Uses Object.getOwnPropertyNames to take the names of all enumerated and unenumerated properties to be used in the JSON.stringify replacer function.