### PR TITLE
fix(colors): update to use default colors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,14 @@ const reservedKey: string[] = [
 const defaultLogger = {
   severity: "debug",
   transport: consoleTransport,
-  transportOptions: {},
+  transportOptions: {
+    colors: {
+      debug: "gray",
+      info: "white",
+      warn: "yellow",
+      error: "red",
+    },
+  },
   levels: {
     debug: 0,
     info: 1,


### PR DESCRIPTION
Adding default colors behaves the way it would seem when initially setting up the project.
Let me know if this isn't something you want in here, it just seems like it should have defaults when you see the image initially and then set it up to see no colors out of the box.

![image](https://github.com/mowispace/react-native-logs/assets/34924300/f4a94048-0a58-4ce5-8cec-339aaea7672d)

fixes #95 