### PR TITLE
Only merge non undefined config values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -548,7 +548,8 @@ const createLogger = <Y extends string>(config?: configLoggerType) => {
     extend: (extension: string) => loggerType;
   };
 
-  const mergedConfig = { ...defaultLogger, ...config };
+  // Merge all non undefined values
+  const mergedConfig = { ...defaultLogger, ...JSON.parse(JSON.stringify(config)) };
 
   return new logs(mergedConfig) as unknown as Omit<logs, "extend"> &
     loggerType &


### PR DESCRIPTION
If you try and create a logger with a conditional in the config and you pass undefined, the sdk will throw an error.

Example:
I was trying to only add a `stringifyFunc` in some cases as added below, but it was causing a crash when initializing the logger. `Uncaught TypeError: this._stringifyFunc is not a function`

```
{
    stringifyFunc: isIos ? () => {...} : undefined
}
```

JSON stringify and parse will remove any undefined values during the merge