### PR TITLE
Improve type definitions

### DIFF
--- a/src/transports/consoleTransport.ts
+++ b/src/transports/consoleTransport.ts
@@ -1,6 +1,6 @@
 import { transportFunctionType } from "../index";
 
-const availableColors: any = {
+const availableColors = {
   default: null,
   black: 30,
   red: 31,
@@ -18,11 +18,21 @@ const availableColors: any = {
   magentaBright: 95,
   cyanBright: 96,
   whiteBright: 97,
-};
+} as const;
 
 const resetColors = "\x1b[0m";
 
-const consoleTransport: transportFunctionType = (props) => {
+type Color = keyof typeof availableColors;
+
+export type ConsoleTransportOptions = {
+  colors?: Record<string, Color>;
+  extensionColors?: Record<string, Color>;
+  consoleFunc?: (msg: string) => void;
+};
+
+const consoleTransport: transportFunctionType<ConsoleTransportOptions> = (
+  props
+) => {
   if (!props) return false;
 
   let msg = props.msg;
@@ -40,13 +50,9 @@ const consoleTransport: transportFunctionType = (props) => {
   if (props.extension && props.options?.extensionColors) {
     let extensionColor = "\x1b[7m";
 
-    if (
-      props.options.extensionColors[props.extension] &&
-      availableColors[props.options.extensionColors[props.extension]]
-    ) {
-      extensionColor = `\x1b[${
-        availableColors[props.options.extensionColors[props.extension]] + 10
-      }m`;
+    const extColor = props.options.extensionColors[props.extension];
+    if (extColor && availableColors[extColor]) {
+      extensionColor = `\x1b[${availableColors[extColor] + 10}m`;
     }
 
     let extStart = color ? resetColors + extensionColor : extensionColor;

--- a/src/transports/crashlyticsTransport.ts
+++ b/src/transports/crashlyticsTransport.ts
@@ -1,6 +1,16 @@
 import { transportFunctionType } from "../index";
 
-const crashlyticsTransport: transportFunctionType = (props) => {
+export type CrashlyticsTransportOption = {
+  CRASHLYTICS: {
+    recordError: (msg: string) => void;
+    log: (msg: string) => void;
+  };
+  errorLevels?: string | Array<string>;
+};
+
+const crashlyticsTransport: transportFunctionType<
+  CrashlyticsTransportOption
+> = (props) => {
   if (!props) return false;
 
   if (!props?.options?.CRASHLYTICS) {

--- a/src/transports/mapConsoleTransport.ts
+++ b/src/transports/mapConsoleTransport.ts
@@ -1,6 +1,14 @@
 import { transportFunctionType } from "../index";
 
-const mapConsoleTransport: transportFunctionType = (props) => {
+type ConsoleMethod = "log" | "warn" | "error" | "info" | (string & {});
+type LogLevel = string;
+
+export type MapConsoleTransportOptions = {
+  mapLevels?: Record<LogLevel, ConsoleMethod>;
+};
+const mapConsoleTransport: transportFunctionType<MapConsoleTransportOptions> = (
+  props
+) => {
   if (!props) return false;
 
   let logMethod = "log";

--- a/src/transports/sentryTransport.ts
+++ b/src/transports/sentryTransport.ts
@@ -1,6 +1,16 @@
 import { transportFunctionType } from "../index";
 
-const sentryTransport: transportFunctionType = (props) => {
+type SentryTransportOptions = {
+  SENTRY: {
+    captureException: (msg: string) => void;
+    addBreadcrumb: (msg: string) => void;
+  };
+  errorLevels?: string | Array<string>;
+};
+
+const sentryTransport: transportFunctionType<SentryTransportOptions> = (
+  props
+) => {
   if (!props) return false;
 
   if (!props?.options?.SENTRY) {


### PR DESCRIPTION
### This PR aims to improve type checking, mostly when setting a transport function.

---

- With the current behaviour, transportOptions can be set to any value, and when setting a transport function, theres no verification if the required options are provided or if its types are correct

![Screenshot 2024-10-22 at 18 28 54](https://github.com/user-attachments/assets/b18b0a18-dfa5-46f5-ae44-6fb5ef7b1adc)

- With this changes, transportOptions type is inferred from the provided transport functions, enforcing the correct types and preventing any required options to be forgotten, liken when setting multiple transport functions

![Screenshot 2024-10-22 at 18 26 36](https://github.com/user-attachments/assets/d032b96a-1652-4ad5-a68e-c778d68b27dc)

The most notable change in this PR is that transportFunctionType is now a generic type, to when previously creating a custom transport could be done like this:

```Typescript
var customTransport: transportFunctionType = (props) => {
  // Do here whatever you want with the log message
  // Eg. a console log: console.log(props.level.text, props.msg)
};
```

will now be like this:

```Typescript
var customTransport: transportFunctionType<{ myCustomOption: string }> = (props) => {
  // Do here whatever you want with the log message
  // Eg. a console log: console.log(props.level.text, props.msg)
};
```
---

- also, with better defined types, some validation code could be removed but thats beyond the scope of this PR